### PR TITLE
Created profile_pictures directory and edited .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,4 +68,3 @@ typings/
 # local uploads
 public/feeds/
 .history/
-public/images/profile_pictures/

--- a/public/images/profile_pictures/.gitignore
+++ b/public/images/profile_pictures/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
I removed the `public/images/profile_pictures/` from `.gitignore` and created the `profile_pictures` folder with its own `.gitignore` file inside, so that the folder itself gets pushed, whilst ignoring any other files it might contain.

I thought it might be better to keep the `profile_pictures` folder in future commits, so there would be no confusion as in #43 